### PR TITLE
Drop illusory support for Node v4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ node_js:
 - 8
 - node
 - 6
-- 4
 before_install:
 - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.3.2
 - export PATH="$HOME/.yarn/bin:$PATH"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "realpath"
   ],
   "engines": {
-    "node": ">=4"
+    "node": ">=6"
   },
   "scripts": {
     "lint": "eslint .",


### PR DESCRIPTION
realpath-native does not actually work on Node.js v4:

```console
$ node --version
v4.9.1
$ npm install --silent realpath-native
realpath-native@1.0.0 node_modules/realpath-native
└── util.promisify@1.0.0 (define-properties@1.1.2, object.getownpropertydescriptors@2.0.3)
$ cat index.js
const realpath = require('realpath-native');

realpath('some-path'); // returns a promise

realpath.sync('some-path');
$ node index.js
/home/capheus/example/node_modules/realpath-native/index.js:25
  return process.binding('fs').realpath(filepath, 'utf8');
                               ^

TypeError: process.binding(...).realpath is not a function
    at Function.realpathSync [as sync] (/home/capheus/example/node_modules/realpath-native/index.js:25:32)
    at Object.<anonymous> (/home/capheus/example/index.js:5:10)
    at Module._compile (module.js:409:26)
    at Object.Module._extensions..js (module.js:416:10)
    at Module.load (module.js:343:32)
    at Function.Module._load (module.js:300:12)
    at Function.Module.runMain (module.js:441:10)
    at startup (node.js:140:18)
    at node.js:1043:3
```