### PR TITLE
Simplify Node version list on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 language: node_js
 node_js:
-- 8
 - node
-- 6
-- 4
 before_install:
 - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.3.2
 - export PATH="$HOME/.yarn/bin:$PATH"


### PR DESCRIPTION
Since Travis CI only executes `yarn commitlint` and `yarn test` (which only runs `eslint`), I don’t think there’s any benefit to running on multiple Node.js versions.