### PR TITLE
Fallback straight to JS if realpath.native/realpathSync.native throw an exception

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ function callWithFallbacks(funcName, filepath) {
       return fs[funcName].native(filepath);
     }
   } catch (err) {
+    // -4068: EISDIR: illegal operation on a directory, realpath
     if (err.errno === -4068) {
       /* Probably RAM-disk on windows.
 			   Go straight to the default js

--- a/index.js
+++ b/index.js
@@ -27,7 +27,10 @@ function callWithFallbacks(funcName, filepath) {
 
     if (fsBinding[funcName]) {
       try {
-        return fsBinding[funcName](filepath, 'utf8');
+        // There is no realpathSync in process.binding
+        // so we always call realpath
+        // see: https://github.com/SimenB/realpath-native/pull/36#issuecomment-463647901
+        return fsBinding.realpath(filepath, 'utf8');
       } catch (err) {
         /* Probably RAM-disk on windows. */
       }

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 const fs = require('fs');
 
 function callWithFallbacks(funcName, filepath) {
-  var fallbackToDefault = false;
+  let fallbackToDefault = false;
 
   try {
     if (typeof fs[funcName].native === 'function') {
@@ -40,7 +40,7 @@ function callWithFallbacks(funcName, filepath) {
 function realpath(filepath) {
   return new Promise((resolve, reject) => {
     try {
-      resolve(callWithFallbacks("realpath", filepath));
+      resolve(callWithFallbacks('realpath', filepath));
     } catch (e) {
       reject(e);
     }
@@ -48,7 +48,7 @@ function realpath(filepath) {
 }
 
 function realpathSync(filepath) {
-  return callWithFallbacks("realpathSync", filepath);
+  return callWithFallbacks('realpathSync', filepath);
 }
 
 module.exports = realpath;

--- a/package.json
+++ b/package.json
@@ -19,9 +19,6 @@
     "lint": "eslint .",
     "test": "eslint . && ava"
   },
-  "dependencies": {
-    "util.promisify": "^1.0.0"
-  },
   "devDependencies": {
     "@commitlint/cli": "^6.0.2",
     "@commitlint/config-conventional": "^6.0.2",


### PR DESCRIPTION
if fs.realpath.native and fs.realpathSync.native crash, it could be because we're on a weird configuration like a RAMdisk on Windows.  if so, fall straight back to default JS implementation.

Otherwise, the process.binding attempt may cause the node runtime to abort

I also refactored the code to reduce repetition.  Let me know if that is ok.

I was unable to run test.js - getting errors doing npm install coming from "babel-helper-regex" and then getting "Cannot find module 'eslint-config-simenb-node'" when trying to run it anyways.

I tested by copying my updated index.js into my project folder under jest-config and running it that way.

This also fixes a potential typo: both realpath and realpathSync were calling realpath in the process.binding attempt, which was probably unintentional.