### PR TITLE
jest-8063: Fix for paths created via SUBST

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ function realpathSync(filepath) {
 
   if (fsBinding.realpath) {
     try {
-      return fsBinding.realpath(filepath, 'utf8');
+      return fsBinding.realpathSync(filepath);
     } catch (err) {
       /* Probably RAM-disk on windows. */
     }


### PR DESCRIPTION
This is a fix for the bug reported here: https://github.com/facebook/jest/issues/8063

I'm not sure if this is the correct fix or not, it would be good to get verification before merge. Though Jest on my local machine is now operating correctly after this change.