### PR TITLE
Feature/windows ramdisk try2

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,14 +16,15 @@ function isWinRamDiskError(err) {
   return err.errno === -4068;
 }
 
-function realpath(filepath, skipToDefault) {
+// Implementation functions
+function realpathImpl(filepath, skipToDefault) {
   if (!skipToDefault) {
     if (typeof fs.realpath.native === 'function') {
-      return promisify(fs.realpath.native)(filepath).catch(function(err) {
+      return promisify(fs.realpath.native)(filepath).catch(function (err) {
         // Call this function again and skip straight to the default
         // js behavior if we've encountered the Windows RAMdisk situation
         if (isWinRamDiskError(err)) {
-          return realpath(filepath, true);
+          return realpathImpl(filepath, true);
         }
       });
     }
@@ -44,7 +45,7 @@ function realpath(filepath, skipToDefault) {
   return promisiedFsRealpath(filepath);
 }
 
-function realpathSync(filepath, skipToDefault) {
+function realpathSyncImpl(filepath, skipToDefault) {
   if (!skipToDefault) {
     try {
       if (typeof fs.realpathSync.native === 'function') {
@@ -54,7 +55,7 @@ function realpathSync(filepath, skipToDefault) {
       // Call this function again and skip straight to the default
       // js behavior if we've encountered the Windows RAMdisk situation
       if (isWinRamDiskError(err)) {
-        return realpathSync(filepath, true);
+        return realpathSyncImpl(filepath, true);
       }
     }
 
@@ -70,6 +71,15 @@ function realpathSync(filepath, skipToDefault) {
   }
 
   return fs.realpathSync(filepath);
+}
+
+// Public API functions
+function realpath(filepath) {
+  return realpathImpl(filepath);
+}
+
+function realpathSync(filepath) {
+  return realpathSyncImpl(filepath);
 }
 
 module.exports = realpath;

--- a/index.js
+++ b/index.js
@@ -1,5 +1,3 @@
-/* eslint-disable prefer-arrow-callback */
-
 'use strict';
 
 const fs = require('fs');
@@ -7,69 +5,59 @@ const promisify = require('util.promisify');
 
 const promisiedFsRealpath = promisify(fs.realpath);
 
-function realpath(filepath) {
-  if (typeof fs.realpath.native === 'function') {
-    return promisify(fs.realpath.native)(filepath).catch(function(err) {
-      // -4068: EISDIR: illegal operation on a directory, realpath
-      if (err.errno !== -4068) {
-        /* If errno === -4068,
-        Probably RAM-disk on windows.
-         Go straight to the default js
-         implementation.  Otherwise the
-         fsBinding.realpath call may cause
-         the node runtime to abort.
-       */
-        const fsBinding = process.binding('fs');
+function isWinRamDiskError(err) {
+  // -4068: EISDIR: illegal operation on a directory, realpath
+  /* Probably RAM-disk on windows.
+     Go straight to the default js
+     implementation.  Otherwise the
+     fsBinding.realpath call may cause
+     the node runtime to abort.
+  */
+  return err.errno === -4068;
+}
 
-        if (fsBinding.realpath) {
-          return new Promise((resolve, reject) => {
-            try {
-              resolve(fsBinding.realpath(filepath, 'utf8'));
-            } catch (e) {
-              reject(e);
-            }
-          });
+function realpath(filepath, skipToDefault) {
+  if (!skipToDefault) {
+    if (typeof fs.realpath.native === 'function') {
+      return promisify(fs.realpath.native)(filepath).catch(function(err) {
+        // Call this function again and skip straight to the default
+        // js behavior if we've encountered the Windows RAMdisk situation
+        if (isWinRamDiskError(err)) {
+          return realpath(filepath, true);
         }
-      }
+      });
+    }
 
-      return promisiedFsRealpath(filepath);
-    });
-  }
-  const fsBinding = process.binding('fs');
+    const fsBinding = process.binding('fs');
 
-  if (fsBinding.realpath) {
-    return new Promise((resolve, reject) => {
-      try {
-        resolve(fsBinding.realpath(filepath, 'utf8'));
-      } catch (e) {
-        reject(e);
-      }
-    });
+    if (fsBinding.realpath) {
+      return new Promise((resolve, reject) => {
+        try {
+          resolve(fsBinding.realpath(filepath, 'utf8'));
+        } catch (e) {
+          reject(e);
+        }
+      });
+    }
   }
 
   return promisiedFsRealpath(filepath);
 }
 
-function realpathSync(filepath) {
-  let fallbackToDefault = false;
-  try {
-    if (typeof fs.realpathSync.native === 'function') {
-      return fs.realpathSync.native(filepath);
+function realpathSync(filepath, skipToDefault) {
+  if (!skipToDefault) {
+    try {
+      if (typeof fs.realpathSync.native === 'function') {
+        return fs.realpathSync.native(filepath);
+      }
+    } catch (err) {
+      // Call this function again and skip straight to the default
+      // js behavior if we've encountered the Windows RAMdisk situation
+      if (isWinRamDiskError(err)) {
+        return realpathSync(filepath, true);
+      }
     }
-  } catch (err) {
-    // -4068: EISDIR: illegal operation on a directory, realpath
-    if (err.errno === -4068) {
-      /* Probably RAM-disk on windows.
-         Go straight to the default js
-         implementation.  Otherwise the
-         fsBinding.realpath call may cause
-         the node runtime to abort.
-       */
-    }
-    fallbackToDefault = true;
-  }
 
-  if (!fallbackToDefault) {
     const fsBinding = process.binding('fs');
 
     if (fsBinding.realpath) {

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+/* eslint-disable prefer-arrow-callback */
+
 'use strict';
 
 const fs = require('fs');
@@ -7,7 +9,30 @@ const promisiedFsRealpath = promisify(fs.realpath);
 
 function realpath(filepath) {
   if (typeof fs.realpath.native === 'function') {
-    return promisify(fs.realpath.native)(filepath);
+    return promisify(fs.realpath.native)(filepath).catch(function(err) {
+      // -4068: EISDIR: illegal operation on a directory, realpath
+      if (err.errno !== -4068) {
+        /* Probably RAM-disk on windows.
+         Go straight to the default js
+         implementation.  Otherwise the
+         fsBinding.realpath call may cause
+         the node runtime to abort.
+       */
+        const fsBinding = process.binding('fs');
+
+        if (fsBinding.realpath) {
+          return new Promise((resolve, reject) => {
+            try {
+              resolve(fsBinding.realpath(filepath, 'utf8'));
+            } catch (e) {
+              reject(e);
+            }
+          });
+        }
+      }
+
+      return promisiedFsRealpath(filepath);
+    });
   }
   const fsBinding = process.binding('fs');
 
@@ -25,17 +50,33 @@ function realpath(filepath) {
 }
 
 function realpathSync(filepath) {
-  if (typeof fs.realpathSync.native === 'function') {
-    return fs.realpathSync.native(filepath);
+  let fallbackToDefault = false;
+  try {
+    if (typeof fs.realpathSync.native === 'function') {
+      return fs.realpathSync.native(filepath);
+    }
+  } catch (err) {
+    // -4068: EISDIR: illegal operation on a directory, realpath
+    if (err.errno === -4068) {
+      /* Probably RAM-disk on windows.
+         Go straight to the default js
+         implementation.  Otherwise the
+         fsBinding.realpath call may cause
+         the node runtime to abort.
+       */
+    }
+    fallbackToDefault = true;
   }
 
-  const fsBinding = process.binding('fs');
+  if (!fallbackToDefault) {
+    const fsBinding = process.binding('fs');
 
-  if (fsBinding.realpath) {
-    try {
-      return fsBinding.realpath(filepath, 'utf8');
-    } catch (err) {
-      /* Probably RAM-disk on windows. */
+    if (fsBinding.realpath) {
+      try {
+        return fsBinding.realpath(filepath, 'utf8');
+      } catch (err) {
+        /* Probably RAM-disk on windows. */
+      }
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -12,7 +12,8 @@ function realpath(filepath) {
     return promisify(fs.realpath.native)(filepath).catch(function(err) {
       // -4068: EISDIR: illegal operation on a directory, realpath
       if (err.errno !== -4068) {
-        /* Probably RAM-disk on windows.
+        /* If errno === -4068,
+        Probably RAM-disk on windows.
          Go straight to the default js
          implementation.  Otherwise the
          fsBinding.realpath call may cause


### PR DESCRIPTION
Not the cleanest of solutions but it works - limiting the check to the specific error message we get from node in this situation.

Could try to deduplicate repeated code in the realpath function but that might hurt readability.