### PR TITLE
Mapped paths broken on Windows machines

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,8 +30,7 @@ function realpathSync(filepath) {
   }
 
   const fsBinding = process.binding('fs');
-  
-  const isWin = process.platform === "win32";
+  const isWin = process.platform === 'win32';
 
   if (fsBinding.realpath && !isWin) {
     try {

--- a/index.js
+++ b/index.js
@@ -30,8 +30,10 @@ function realpathSync(filepath) {
   }
 
   const fsBinding = process.binding('fs');
+  
+  const isWin = process.platform === "win32";
 
-  if (fsBinding.realpath) {
+  if (fsBinding.realpath && !isWin) {
     try {
       return fsBinding.realpath(filepath, 'utf8');
     } catch (err) {

--- a/test.js
+++ b/test.js
@@ -3,9 +3,9 @@ import test from 'ava';
 import realpath from '.';
 
 test('async', async t => {
-  t.is(path.basename(await realpath('fixture.js')), 'test.js');
+  t.is(path.basename(await realpath('fixture.js')), 'fixture.js');
 });
 
 test('sync', t => {
-  t.is(path.basename(realpath.sync('fixture.js')), 'test.js');
+  t.is(path.basename(realpath.sync('fixture.js')), 'fixture.js');
 });


### PR DESCRIPTION
Windows machines with mapped drives fail to find unit tests.  If a C:\projects\test.js drive is mapped to H:\test.js, running jest unit tests will search for H:\test.js inside of C:\projects which will obviously fail.  We noticed this behavior when we upgraded our jest to 24.x and after a lot of troubleshooting we see that the process.binding('fs') seems to be the culprit.